### PR TITLE
Make dashboard shell responsive (mobile-first with breakpoint layouts)

### DIFF
--- a/src/components/dashboard/artistsScreen/ArtistsScreen.jsx
+++ b/src/components/dashboard/artistsScreen/ArtistsScreen.jsx
@@ -12,7 +12,7 @@ const Skeleton = lazy(() => import('./Skeleton'))
 const Options = lazy(() => import('../routeTypes/components/Options'))
 const ShareScreen = lazy(() => import('./ShareScreen'))
 
-const ArtistsScreen = ({ isPublic }) => {
+const ArtistsScreen = ({ isPublic, isOpen = false, onClose }) => {
   const [currentSong] = useRQGlobalState('currentSong', null)
   const [playbackDetails] = useRQGlobalState('playbackQueue')
   const [artistsData, setArtistsData] = useState(null)
@@ -52,91 +52,126 @@ const ArtistsScreen = ({ isPublic }) => {
     }
   }
 
+  const panelContent = (
+    <>
+      {/* display nowPlaying screen*/}
+      {selectedScreen?.data === 'nowPlaying' && (
+        <motion.div
+          key='details'
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.5 }}
+        >
+          {data ? (
+            <div className={!isPublic && 'p-4'}>
+              {!isPublic && (
+                <SongDetails
+                  handleMenu={(type, id) => handleMenu(type, id)}
+                  songData={data}
+                  showMenu={(type) => setSelectedScreen(type)}
+                />
+              )}
+              <div className={isPublic && 'max-h-[50vh] overflow-y-scroll'}>
+                {artistsData?.data && (
+                  <ArtistDetails
+                    handleMenu={(type, id) => handleMenu(type, id)}
+                    artistData={artistsData?.data}
+                    songData={data}
+                    isPublic={isPublic}
+                  />
+                )}
+                <Credits
+                  handleMenu={(type, id) => handleMenu(type, id)}
+                  songData={data}
+                />
+                <NextQueue
+                  showMenu={(type) => setSelectedScreen(type)}
+                  queueData={playbackDetails?.data}
+                  handleMenu={(type, id) => handleMenu(type, id)}
+                />
+              </div>
+            </div>
+          ) : (
+            <Skeleton />
+          )}
+        </motion.div>
+      )}
+
+      {/* display lyrics screen*/}
+      {selectedScreen?.data === 'lyrics' && (
+        <motion.div
+          key='lyrics'
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.5 }}
+        >
+          <LyricsScreen
+            lyricsData={currentLyrics}
+            songData={data}
+            showMenu={(type) => setSelectedScreen(type)}
+            isPublic={isPublic}
+          />
+        </motion.div>
+      )}
+
+      {/* display queue screen*/}
+      {selectedScreen?.data === 'queue' && (
+        <motion.div
+          key='lyrics'
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.5 }}
+        >
+          <QueueScreen
+            showMenu={(type) => setSelectedScreen(type)}
+            handleMenu={(type, id) => handleMenu(type, id)}
+            isPublic={isPublic}
+          />
+        </motion.div>
+      )}
+    </>
+  )
+
   return (
     <AnimatePresence>
       <div
         className={
           isPublic
             ? 'overflow-scroll bg-[#0f0f0f] rounded-lg h-auto col-span-4 select-none'
-            : 'overflow-scroll bg-[#0f0f0f] m-2 ml-1 rounded-lg h-auto col-span-4 select-none'
+            : 'hidden overflow-scroll bg-[#0f0f0f] m-2 ml-1 rounded-lg h-[calc(100vh-5rem)] select-none lg:block lg:col-span-4'
         }
       >
-        {/* display nowPlaying screen*/}
-        {selectedScreen?.data === 'nowPlaying' && (
-          <motion.div
-            key='details'
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.5 }}
-          >
-            {data ? (
-              <div className={!isPublic && 'p-4'}>
-                {!isPublic && (
-                  <SongDetails
-                    handleMenu={(type, id) => handleMenu(type, id)}
-                    songData={data}
-                    showMenu={(type) => setSelectedScreen(type)}
-                  />
-                )}
-                <div className={isPublic && 'max-h-[50vh] overflow-y-scroll'}>
-                  {artistsData?.data && (
-                    <ArtistDetails
-                      handleMenu={(type, id) => handleMenu(type, id)}
-                      artistData={artistsData?.data}
-                      songData={data}
-                      isPublic={isPublic}
-                    />
-                  )}
-                  <Credits
-                    handleMenu={(type, id) => handleMenu(type, id)}
-                    songData={data}
-                  />
-                  <NextQueue
-                    showMenu={(type) => setSelectedScreen(type)}
-                    queueData={playbackDetails?.data}
-                    handleMenu={(type, id) => handleMenu(type, id)}
-                  />
-                </div>
-              </div>
-            ) : (
-              <Skeleton />
-            )}
-          </motion.div>
-        )}
-
-        {/* display lyrics screen*/}
-        {selectedScreen?.data === 'lyrics' && (
-          <motion.div
-            key='lyrics'
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.5 }}
-          >
-            <LyricsScreen
-              lyricsData={currentLyrics}
-              songData={data}
-              showMenu={(type) => setSelectedScreen(type)}
-              isPublic={isPublic}
-            />
-          </motion.div>
-        )}
-
-        {/* display queue screen*/}
-        {selectedScreen?.data === 'queue' && (
-          <motion.div
-            key='lyrics'
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.5 }}
-          >
-            <QueueScreen
-              showMenu={(type) => setSelectedScreen(type)}
-              handleMenu={(type, id) => handleMenu(type, id)}
-              isPublic={isPublic}
-            />
-          </motion.div>
-        )}
+        {panelContent}
       </div>
+
+      {!isPublic && isOpen && (
+        <motion.div
+          className='fixed inset-0 z-50 bg-black/70 lg:hidden'
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <motion.div
+            className='absolute bottom-0 left-0 right-0 max-h-[85vh] overflow-y-auto rounded-t-2xl bg-[#0f0f0f] p-4 shadow-2xl'
+            initial={{ y: '100%' }}
+            animate={{ y: 0 }}
+            exit={{ y: '100%' }}
+            transition={{ type: 'spring', damping: 28, stiffness: 260 }}
+          >
+            <div className='mb-4 flex items-center justify-between'>
+              <h2 className='text-lg font-bold'>Now playing</h2>
+              <button
+                aria-label='Close now playing panel'
+                className='rounded-full bg-[#242424] p-2'
+                onClick={onClose}
+              >
+                <MdClose size={22} />
+              </button>
+            </div>
+            {panelContent}
+          </motion.div>
+        </motion.div>
+      )}
 
       {/* handle recently played automatically */}
       {!isPublic && currentSong?.data && (
@@ -163,16 +198,12 @@ const ArtistsScreen = ({ isPublic }) => {
 
 const SongDetails = ({ handleMenu, songData, showMenu }) => {
   const [showQR, setShowQR] = useState(false)
-  const [url, setUrl] = useState(
-    'https://sparklines.vercel.app/'
-  )
+  const [url, setUrl] = useState('https://sparklines.vercel.app/')
   const artist = songData?.primaryArtists?.split(',').slice(0, 2)
   const artistId = songData?.primaryArtistsId?.replaceAll(' ', '').split(',')
 
   useEffect(() => {
-    setUrl(
-      `https://sparklines.vercel.app/public/${songData?.id}`
-    )
+    setUrl(`https://sparklines.vercel.app/public/${songData?.id}`)
   }, [songData])
 
   return (

--- a/src/components/dashboard/header/Header.jsx
+++ b/src/components/dashboard/header/Header.jsx
@@ -1,10 +1,11 @@
 import { FaHistory } from 'react-icons/fa'
 import { FaGithub } from 'react-icons/fa6'
+import { MdQueueMusic } from 'react-icons/md'
 import { useNavigate } from 'react-router-dom'
 import Buttons from './Buttons'
 import UserProfile from './profile/UserProfile'
 
-const Header = () => {
+const Header = ({ onOpenArtistsPanel }) => {
   const navigate = useNavigate()
 
   return (
@@ -27,6 +28,16 @@ const Header = () => {
         <button>
           <FaHistory
             onClick={() => navigate('/dashboard/recently-played')}
+            size={30}
+            className='p-1 opacity-80 bg-black rounded-full'
+          />
+        </button>
+        <button
+          aria-label='Open now playing panel'
+          className='lg:hidden'
+          onClick={onOpenArtistsPanel}
+        >
+          <MdQueueMusic
             size={30}
             className='p-1 opacity-80 bg-black rounded-full'
           />

--- a/src/components/dashboard/mainScreen/MainScreen.jsx
+++ b/src/components/dashboard/mainScreen/MainScreen.jsx
@@ -11,11 +11,11 @@ const Discography = lazy(() => import('../routeTypes/components/Discography'))
 const LikedSongs = lazy(() => import('../routeTypes/LikedSongs'))
 const Playlists = lazy(() => import('../routeTypes/Playlists'))
 
-const MainScreen = ({ showMenu }) => {
+const MainScreen = ({ showMenu, onOpenArtistsPanel }) => {
   return (
-    <div className='bg-[#0f0f0f] overflow-y-auto h-auto my-2 mx-1 rounded-lg col-span-8'>
+    <div className='w-full overflow-y-auto bg-[#0f0f0f] h-[calc(100vh-8rem)] lg:h-[calc(100vh-5rem)] my-2 mx-1 rounded-lg lg:col-span-8'>
       <div className='relative '>
-        <Header />
+        <Header onOpenArtistsPanel={onOpenArtistsPanel} />
       </div>
       {showMenu === 'search' && <Search />}
       {showMenu === 'home' && <Homepage />}

--- a/src/components/dashboard/menuBar/MenuBar.jsx
+++ b/src/components/dashboard/menuBar/MenuBar.jsx
@@ -45,28 +45,28 @@ const MenuBar = () => {
   }
 
   return (
-    <div className='flex flex-col h-auto m-2 mr-1 rounded-lg'>
-      <div className='bg-[#0f0f0f] mb-2 rounded-lg flex-none p-5'>
+    <div className='fixed bottom-0 left-0 right-0 z-50 flex h-16 flex-row m-0 rounded-none bg-black p-1 lg:static lg:z-auto lg:h-auto lg:flex-col lg:m-2 lg:mr-1 lg:rounded-lg lg:bg-transparent lg:p-0'>
+      <div className='bg-[#0f0f0f] mb-0 rounded-lg flex flex-1 items-center justify-center p-3 lg:mb-2 lg:block lg:flex-none lg:p-5'>
         {menu === 'home' && (
-          <div>
+          <div className='flex items-center gap-6 lg:block'>
             <Link to='/dashboard'>
               <MdHome size={30} onClick={handleMenu2} />
             </Link>
             <Link to='/dashboard/search'>
               <RiSearchLine
                 size={28}
-                className='opacity-70 mt-5'
+                className='opacity-70 lg:mt-5'
                 onClick={handleMenu1}
               />
             </Link>
           </div>
         )}
         {menu === 'search' && (
-          <div>
+          <div className='flex items-center gap-6 lg:block'>
             <Link to='/dashboard'>
               <MdOutlineHome
                 size={30}
-                className='opacity-70 mb-5'
+                className='opacity-70 lg:mb-5'
                 onClick={handleMenu2}
               />
             </Link>
@@ -76,7 +76,7 @@ const MenuBar = () => {
           </div>
         )}
       </div>
-      <div className='bg-[#0f0f0f] rounded-lg py-5 grow overflow-y-auto'>
+      <div className='hidden bg-[#0f0f0f] rounded-lg py-5 grow overflow-y-auto lg:block'>
         <LuLibrary size={30} className='opacity-70 mb-5 ml-5' />
         <Link to='/dashboard/liked'>
           <div className='w-10 mb-4 mx-4' onClick={handleMenu1}>

--- a/src/components/dashboard/playback/MenuButtons.jsx
+++ b/src/components/dashboard/playback/MenuButtons.jsx
@@ -7,12 +7,8 @@ import useRQGlobalState from '../../../utils/useRQGlobalState'
 import Options from '../routeTypes/components/Options'
 import { DownloadURL } from '../artistsScreen/ArtistsScreen'
 
-
-const MenuButtons = ({ isPublic }) => {
-  const [selectedScreen, setSelectedScreen] = useRQGlobalState(
-    'contentPlay',
-    'nowPlaying'
-  )
+const MenuButtons = ({ isPublic, onOpenArtistsPanel }) => {
+  const [, setSelectedScreen] = useRQGlobalState('contentPlay', 'nowPlaying')
   const [isLike, setLiked] = useState(false)
   const [isShowNowPlaying, showNowPlaying] = useState(true)
   const [isShowLyrics, showLyrics] = useState(false)
@@ -30,18 +26,21 @@ const MenuButtons = ({ isPublic }) => {
       showLyrics(false)
       showQueue(false)
       setSelectedScreen('nowPlaying')
+      onOpenArtistsPanel?.()
     }
     if (type === 'lyrics') {
       showNowPlaying(false)
       showLyrics(!isShowLyrics)
       showQueue(false)
       setSelectedScreen('lyrics')
+      onOpenArtistsPanel?.()
     }
     if (type === 'queue') {
       showNowPlaying(false)
       showLyrics(false)
       showQueue(!isShowqueue)
       setSelectedScreen('queue')
+      onOpenArtistsPanel?.()
     }
     if (type === 'devices') {
       setDevices(!isDevices)
@@ -49,7 +48,13 @@ const MenuButtons = ({ isPublic }) => {
   }
 
   return (
-    <div className={isPublic ? 'mt-10 ml-44 flex justify-center gap-4 opacity-80' :'mt-6 ml-20 flex justify-center gap-4 opacity-70'}>
+    <div
+      className={
+        isPublic
+          ? 'mt-10 ml-44 flex justify-center gap-4 opacity-80'
+          : 'mt-2 flex justify-center gap-4 opacity-70 lg:mt-6 lg:ml-20'
+      }
+    >
       {!isPublic && (
         <Options
           type='liked'
@@ -92,7 +97,9 @@ const MenuButtons = ({ isPublic }) => {
           className='cursor-pointer'
         />
       )}
-      {isPublic && <DownloadURL songData={currentSong?.data} isPublic={isPublic}/>}
+      {isPublic && (
+        <DownloadURL songData={currentSong?.data} isPublic={isPublic} />
+      )}
     </div>
   )
 }

--- a/src/components/dashboard/playback/Playback.jsx
+++ b/src/components/dashboard/playback/Playback.jsx
@@ -15,12 +15,12 @@ const Container = styled.div`
   ${tw`bg-black w-screen p-1 text-sm font-semibold`}
 `
 const SubContainer = styled.div`
-  ${tw`grid grid-cols-3 justify-between`}
+  ${tw`grid grid-cols-2 items-center gap-2 lg:grid-cols-3 lg:justify-between`}
 `
 
 const Player = () => {
   const audioRef = useRef()
-  const [playerRef, setPlayerRef] = useRQGlobalState('playerRef', null)
+  const [, setPlayerRef] = useRQGlobalState('playerRef', null)
   const [playbackDetails, setPlaybackDetails] =
     useRQGlobalState('playbackQueue')
   const [currentSong, setCurrentSong] = useRQGlobalState('currentSong', null)
@@ -84,7 +84,10 @@ const Player = () => {
     }
 
     if (isPublic && albumsResponse?.data?.results) {
-      const updatedData = [playbackDetails?.data[0], ...albumsResponse?.data?.results]
+      const updatedData = [
+        playbackDetails?.data[0],
+        ...albumsResponse.data.results,
+      ]
 
       setPlaybackDetails(updatedData)
     }
@@ -103,7 +106,7 @@ const Player = () => {
   )
 }
 
-const Playback = ({ isPublic }) => {
+const Playback = ({ isPublic, onOpenArtistsPanel }) => {
   const [currentSong] = useRQGlobalState('currentSong', null)
 
   // Set Webpage Title
@@ -118,13 +121,13 @@ const Playback = ({ isPublic }) => {
       {!isPublic && (
         <Container>
           <SubContainer>
-            <div className='flex'>
+            <div className='flex min-w-0'>
               <AudioDetails />
               <AudioVisualizer />
             </div>
             <AudioController />
-            <div className='flex'>
-              <MenuButtons />
+            <div className='col-span-2 flex justify-end lg:col-span-1'>
+              <MenuButtons onOpenArtistsPanel={onOpenArtistsPanel} />
               <VolumeController />
             </div>
           </SubContainer>

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -12,11 +12,12 @@ const ArtistsScreen = lazy(
 )
 
 const Container = styled.div`
-  ${tw`overflow-y-hidden bg-black text-white w-screen h-auto`}
+  ${tw`overflow-hidden bg-black text-white w-screen min-h-screen`}
 `
 
 const Dashboard = () => {
   const [showMenu, setShowMenu] = useState('home')
+  const [showArtistsPanel, setShowArtistsPanel] = useState(false)
   var userId = localStorage.getItem('userId')
   const navigate = useNavigate()
   const location = useLocation()
@@ -75,16 +76,22 @@ const Dashboard = () => {
 
   return (
     <Container>
-      <div>
-        <div className='grid grid-rows-8 w-screen h-screen'>
-          <div className='flex row-span-9'>
-            <MenuBar />
-            <div className='grid grid-cols-12'>
-              <MainScreen showMenu={showMenu} />
-              <ArtistsScreen />
-            </div>
+      <div className='relative flex h-screen w-screen flex-col overflow-hidden pb-32 lg:pb-0'>
+        <div className='flex min-h-0 flex-1 flex-col lg:flex-row'>
+          <MenuBar />
+          <div className='grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-12'>
+            <MainScreen
+              showMenu={showMenu}
+              onOpenArtistsPanel={() => setShowArtistsPanel(true)}
+            />
+            <ArtistsScreen
+              isOpen={showArtistsPanel}
+              onClose={() => setShowArtistsPanel(false)}
+            />
           </div>
-          <Playback />
+        </div>
+        <div className='fixed bottom-16 left-0 right-0 z-40 lg:static'>
+          <Playback onOpenArtistsPanel={() => setShowArtistsPanel(true)} />
         </div>
       </div>
     </Container>


### PR DESCRIPTION
### Motivation
- Convert the dashboard to a mobile-first layout so the main content, playback and navigation adapt to small screens while restoring the three-panel desktop layout at `lg`/`xl` breakpoints.
- Hide the artist/queue panel on mobile and expose it as a sheet/modal to reduce visual clutter and keep playback controls accessible.
- Ensure the main scroll container uses viewport-aware heights so content scrolls within the viewport instead of growing the page.

### Description
- Reworked the dashboard shell in `src/pages/Dashboard.jsx` from a fixed desktop grid to a mobile-first flex layout with `lg:` breakpoints restoring the multi-column desktop grid and a fixed/sticky mobile playback area.
- Updated `src/components/dashboard/mainScreen/MainScreen.jsx` to accept an `onOpenArtistsPanel` prop, changed `col-span-8` to `w-full lg:col-span-8`, and replaced `h-auto` with viewport-aware heights (`h-[calc(100vh-8rem)]` and `lg:h-[calc(100vh-5rem)]`).
- Converted the artist/current-song panel `src/components/dashboard/artistsScreen/ArtistsScreen.jsx` into a desktop-only side panel (`hidden lg:block lg:col-span-4`) and added a mobile sheet/modal controlled via `isOpen`/`onClose` props that renders the same panel content for now-playing/lyrics/queue.
- Turned the sidebar `MenuBar` into a bottom navigation on small screens and restored the vertical sidebar at `lg` in `src/components/dashboard/menuBar/MenuBar.jsx`.
- Added a header button (`MdQueueMusic`) to open the now-playing sheet and updated playback/menu buttons to open the mobile sheet by wiring `onOpenArtistsPanel` through `Header`, `Playback`, and `MenuButtons`.
- Adjusted playback layout grid classes in `src/components/dashboard/playback/Playback.jsx` for responsive spacing and removed unused local variables where needed.

### Testing
- Ran `npm run build` which completed successfully and produced a production build without runtime errors.
- Ran linting via `npm run lint` and targeted `eslint` runs; linting surfaced pre-existing repository issues and warnings (TUI-related hook/component naming and some exhaustive-deps warnings) so lint did not fully pass across the entire repo but the changes introduced only a small number of warnings that were addressed where safe.
- Verified application compiles and the updated dashboard files are included in the build artifacts; no runtime errors were observed during the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3946662780832fb775516bb3192da2)